### PR TITLE
Fix copyFromLocal command in Hadoop 2.x does not generate directories recursively

### DIFF
--- a/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/hadoop/beans/system/HDFS2.scala
+++ b/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/hadoop/beans/system/HDFS2.scala
@@ -72,6 +72,7 @@ class HDFS2(version: String, lifespan: Lifespan, dependencies: Set[System] = Set
           }
       }
     }
+    mkdir(config.getString(s"system.$configKey.path.input"))
   }
 
   override protected def stop() = {
@@ -107,6 +108,11 @@ class HDFS2(version: String, lifespan: Lifespan, dependencies: Set[System] = Set
       shell ! s"""gunzip -c \"$src\" | $hadoopHome/bin/hadoop fs -put - \"$dst\" """
     else
       shell ! s"""$hadoopHome/bin/hadoop fs -copyFromLocal "$src" "$dst" """
+  }
+
+  def mkdir(dir: String) = {
+    val hadoopHome = config.getString(s"system.$configKey.path.home")
+    shell ! s"""$hadoopHome/bin/hadoop fs -mkdir -p "$dir" """
   }
 
   // ---------------------------------------------------


### PR DESCRIPTION
The directory for input file has to be generated manually in hdfs-2
