### PR TITLE
Add experiemnt name and runner in State

### DIFF
--- a/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/flink/beans/experiment/FlinkExperiment.scala
+++ b/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/flink/beans/experiment/FlinkExperiment.scala
@@ -3,6 +3,7 @@ package eu.stratosphere.peel.extensions.flink.beans.experiment
 import java.io.FileWriter
 import java.nio.file.{Files, Paths}
 
+import java.lang.{System => Sys}
 import com.typesafe.config.Config
 import eu.stratosphere.peel.core.beans.data.{DataSet, ExperimentOutput}
 import eu.stratosphere.peel.core.beans.experiment.Experiment
@@ -49,13 +50,16 @@ class FlinkExperiment(command: String,
 object FlinkExperiment {
 
   case class State(name: String,
+                   suiteName: String,
                    command: String,
+                   runnerName: String,
+                   runnerVersion: String,
                    var runExitCode: Option[Int] = None,
                    var runTime: Long = 0,
                    var plnExitCode: Option[Int] = None) extends Experiment.RunState {}
 
   object StateProtocol extends DefaultJsonProtocol with NullOptions {
-    implicit val stateFormat = jsonFormat5(State)
+    implicit val stateFormat = jsonFormat8(State)
   }
 
   /** A private inner class encapsulating the logic of single run. */
@@ -74,10 +78,10 @@ object FlinkExperiment {
         try {
           io.Source.fromFile(s"$home/state.json").mkString.parseJson.convertTo[State]
         } catch {
-          case e: Throwable => State(name, command)
+          case e: Throwable => State(name, Sys.getProperty("app.suite.name"), command, exp.runner.name, exp.runner.version)
         }
       } else {
-        State(name, command)
+        State(name, Sys.getProperty("app.suite.name"), command, exp.runner.name, exp.runner.version)
       }
     }
 

--- a/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/spark/beans/experiment/SparkExperiment.scala
+++ b/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/spark/beans/experiment/SparkExperiment.scala
@@ -49,12 +49,15 @@ class SparkExperiment(command: String,
 object SparkExperiment {
 
   case class State(name: String,
+                   suiteName: String,
                    command: String,
+                   runnerName: String,
+                   runnerVersion: String,
                    var runExitCode: Option[Int] = None,
                    var runTime: Long = 0) extends Experiment.RunState {}
 
   object StateProtocol extends DefaultJsonProtocol with NullOptions {
-    implicit val stateFormat = jsonFormat4(State)
+    implicit val stateFormat = jsonFormat7(State)
   }
 
   /**
@@ -75,10 +78,10 @@ object SparkExperiment {
         try {
           io.Source.fromFile(s"$home/state.json").mkString.parseJson.convertTo[State]
         } catch {
-          case e: Throwable => State(name, command)
+          case e: Throwable => State(name, Sys.getProperty("app.suite.name"), command, exp.runner.name, exp.runner.version)
         }
       } else {
-        State(name, command)
+        State(name, Sys.getProperty("app.suite.name"), command, exp.runner.name, exp.runner.version)
       }
     }
 


### PR DESCRIPTION
This commit from Mingliang extends the "state.json" file with name and version of the executed system.  The analyser extension relies on this information. We just forget to add it to the pull request of the analyser, because this commit was located in Mingliangs repository...