### PR TITLE
Separate setup & tear down of systems required for datasets from experiments

### DIFF
--- a/peel-core/src/main/scala/eu/stratosphere/peel/core/beans/data/GeneratedDataSet.scala
+++ b/peel-core/src/main/scala/eu/stratosphere/peel/core/beans/data/GeneratedDataSet.scala
@@ -13,7 +13,7 @@ import eu.stratosphere.peel.core.beans.system.{FileSystem, Job, System}
   * @param dst The path where the data is stored. The job has to make sure that the data is actually stored at that location.
   * @param fs Filesystem that is used to check if this dataset already exists.
   */
-class GeneratedDataSet(val src: Job[System], val dst: String, fs: System with FileSystem) extends DataSet(dst, Set[System](fs)) {
+class GeneratedDataSet(val src: Job[System], val dst: String, fs: System with FileSystem) extends DataSet(dst, Set[System](fs, src.runner)) {
 
   import scala.language.implicitConversions
 

--- a/peel-core/src/main/scala/eu/stratosphere/peel/core/cli/command/experiment/SetUp.scala
+++ b/peel-core/src/main/scala/eu/stratosphere/peel/core/cli/command/experiment/SetUp.scala
@@ -7,7 +7,7 @@ import eu.stratosphere.peel.core.beans.experiment.ExperimentSuite
 import eu.stratosphere.peel.core.beans.system.{Lifespan, System}
 import eu.stratosphere.peel.core.cli.command.Command
 import eu.stratosphere.peel.core.config.{Configurable, loadConfig}
-import eu.stratosphere.peel.core.graph.createGraph
+import eu.stratosphere.peel.core.graph.{Node, createGraph}
 import net.sourceforge.argparse4j.inf.{Namespace, Subparser}
 import org.springframework.context.ApplicationContext
 
@@ -67,6 +67,12 @@ class SetUp extends Command {
     if (expOption.isEmpty) throw new RuntimeException(s"Experiment '$expName' either not found or ambigous in suite '$suiteName'")
 
     for (exp <- expOption) {
+
+      val inputSystems: Set[Node] = for (in <- exp.inputs; sys <- in.dependencies) yield sys
+      val expOnly = graph.descendants(exp, exp.inputs).diff(Seq(exp)).toSet
+      val inputOnly = inputSystems.diff(expOnly)
+      val expAll = for (n <- graph.reverse.traverse(); if graph.descendants(exp).contains(n)) yield n
+
       try {
         // update config
         exp.config = loadConfig(graph, exp)
@@ -75,20 +81,33 @@ class SetUp extends Command {
           case _ => Unit
         }
 
-        logger.info("Setting up systems with SUITE or EXPERIMENT lifespan")
-        for (n <- graph.reverse.traverse(); if graph.descendants(exp).contains(n)) n match {
-          case s: System => if ((Lifespan.SUITE :: Lifespan.EXPERIMENT :: Nil contains s.lifespan) && !s.isUp) s.setUp()
+        logger.info("Setting up systems required for input data sets")
+        for (n <- inputSystems) n match {
+          case s: System => s.setUp()
           case _ => Unit
         }
 
         logger.info("Materializing experiment input data sets")
         for (n <- exp.inputs) n.materialize()
+
+        logger.info("Tearing down redundant systems before conducting experiment runs")
+        for (n <- inputOnly) n match {
+          case s: System if !(Lifespan.PROVIDED :: Lifespan.SUITE :: Nil contains s.lifespan) => s.tearDown()
+          case _ => Unit
+        }
+
+        logger.info("Setting up systems with EXPERIMENT lifespan")
+        for (n <- expOnly) n match {
+          case s: System if Lifespan.EXPERIMENT :: Nil contains s.lifespan => s.setUp()
+          case _ => Unit
+        }
+
       } catch {
         case e: Throwable =>
           logger.error(s"Exception of type ${e.getClass.getCanonicalName} for experiment ${exp.name} in suite ${suite.name}: ${e.getMessage}")
 
-          logger.info("Tearing down runing systems with SUITE or EXPERIMENT lifespan")
-          for (n <- graph.traverse(); if graph.descendants(exp).contains(n)) n match {
+          logger.info("Tearing down running systems with SUITE or EXPERIMENT lifespan")
+          for (n <- expAll) n match {
             case s: System => if ((Lifespan.SUITE :: Lifespan.EXPERIMENT :: Nil contains s.lifespan) && s.isUp) s.tearDown()
             case _ => Unit
           }


### PR DESCRIPTION
The current behavior in peel, that started all systems required by the experiments in a suite, led to problems if, for instance, the systems together required more memory than available.

With these changes, only the systems required for the data generation are started and afterwards shut down and then only the systems required for the specific experiment are started (if not already started by the data generation)