### PR TITLE
Fixed bug related to BSD wc.

### DIFF
--- a/peel-core/src/main/scala/eu/stratosphere/peel/core/beans/experiment/Experiment.scala
+++ b/peel-core/src/main/scala/eu/stratosphere/peel/core/beans/experiment/Experiment.scala
@@ -169,7 +169,7 @@ object Experiment {
     /** Before the run, collect runner log files and their current line counts */
     protected def beforeRun() = {
       val logFiles = for (pattern <- logFilePatterns; f <- (shell !! s"ls $pattern").split(Sys.lineSeparator).map(_.trim)) yield f
-      logFileCounts = Map((for (f <- logFiles) yield f -> (shell !! s"wc -l $f | cut -d' ' -f1").trim.toLong): _*)
+      logFileCounts = Map((for (f <- logFiles) yield f -> (shell !! s"wc -l $f | xargs | cut -d' ' -f1").trim.toLong): _*)
     }
 
     /** After the run, copy logs */


### PR DESCRIPTION
Executing `xargs` in between counting lines (`wc -l`) and cutting the linescount (`cut -d' ' -f1`)
trims the leading spaces introduced by BSD `wc`.