### PR TITLE
Fix command trimming in FlinkExperiment

### DIFF
--- a/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/flink/beans/experiment/FlinkExperiment.scala
+++ b/peel-extensions/src/main/scala/eu/stratosphere/peel/extensions/flink/beans/experiment/FlinkExperiment.scala
@@ -84,11 +84,11 @@ object FlinkExperiment {
           if (Version(exp.runner.version) <= Version("0.8")) Some("-e") else Option.empty[String]
         )
         // execute command
-        Experiment.time(this !(s"info ${opts.flatten.mkString(" ")} $command", s"$home/run.pln", s"$home/run.pln"))
+        Experiment.time(this !(s"info ${opts.flatten.mkString(" ")} ${command.trim}", s"$home/run.pln", s"$home/run.pln"))
       }
       state.plnExitCode = Some(plnExit)
       // try to execute the experiment run plan
-      val (runExit, t) = Experiment.time(this !(s"run $command", s"$home/run.out", s"$home/run.err"))
+      val (runExit, t) = Experiment.time(this !(s"run ${command.trim}", s"$home/run.out", s"$home/run.err"))
       state.runTime = t
       state.runExitCode = Some(runExit)
     }


### PR DESCRIPTION
The old logic was to prepend the Flink command (`run`, `info`) and then
trim the resulting command. The bug occured when there is a leading
newline in the parameters. With this fix the parameters are trimmed
first and then the Flink command is prepended.