### PR TITLE
Fixed NOTICE file

### DIFF
--- a/.license-mappings.xml
+++ b/.license-mappings.xml
@@ -28,5 +28,6 @@
         <artifactId>monetdb-jdbc</artifactId>
         <version>11.19.15</version>
         <license>MonetDB Public License Version 1.1</license>
+        <name>monetdb-jdbc</name>
     </artifact>
 </license-lookup>

--- a/NOTICE
+++ b/NOTICE
@@ -39,7 +39,7 @@ This project includes:
   Joda-Time under Apache 2
   JUnit under Common Public License Version 1.0
   Mockito under The MIT License
-  monetdb:monetdb-jdbc under MonetDB Public License Version 1.1
+  monetdb-jdbc under MonetDB Public License Version 1.1
   Objenesis under MIT License
   parboiled-core under Apache 2
   parboiled-java under Apache 2


### PR DESCRIPTION
The monetdb project name did not match the expected format, hence the
build was failing due to the check-notice maven plugin.