### PR TITLE
Use a local PID directory with Apache Flink

### DIFF
--- a/peel-extensions/src/main/resources/reference.flink.conf
+++ b/peel-extensions/src/main/resources/reference.flink.conf
@@ -20,7 +20,7 @@ system {
             # flink.yaml entries
             yaml {
                 env.java.home = ${system.default.config.java.home}
-                env.pid.dir = ${system.flink.path.home}
+                env.pid.dir = "/tmp"
                 parallelism.default = ${system.default.config.parallelism.total}
                 jobmanager.rpc.address = "localhost"
                 taskmanager.tmp.dirs = "/tmp/flink"


### PR DESCRIPTION
Peel residents most of the time on a shared folder.
Flink use ,,flink-[USERNAME]-taskmanager.pid'' as its pid filename
pattern wich results in one pid file per cluster and a lot of trouble if
all hosts using the same shared folder...
This fix use a local tmp folder as default to ensure host specific pid files.

The bug was added in #56 and other platforms might have the same bug. 