### PR TITLE
Set the peel-version in the archetype POMs to 1.0.0-beta.

### DIFF
--- a/peel-archetypes/peel-flink-bundle/src/main/resources/archetype-resources/pom.xml
+++ b/peel-archetypes/peel-flink-bundle/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Peel -->
-        <peel.version>1.0-SNAPSHOT</peel.version>
+        <peel.version>1.0.0-beta</peel.version>
     </properties>
 
     <dependencyManagement>

--- a/peel-archetypes/peel-flinkspark-bundle/src/main/resources/archetype-resources/pom.xml
+++ b/peel-archetypes/peel-flinkspark-bundle/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Peel -->
-        <peel.version>1.0-SNAPSHOT</peel.version>
+        <peel.version>1.0.0-beta</peel.version>
     </properties>
 
     <dependencyManagement>

--- a/peel-archetypes/peel-spark-bundle/src/main/resources/archetype-resources/pom.xml
+++ b/peel-archetypes/peel-spark-bundle/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Peel -->
-        <peel.version>1.0-SNAPSHOT</peel.version>
+        <peel.version>1.0.0-beta</peel.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This should make the peel-version consistent with the version deployed to the maven repository.