### PR TITLE
Add flink-0.10.1 system

### DIFF
--- a/peel-archetypes/peel-flink-bundle/src/main/resources/archetype-resources/__rootArtifactId__-bundle/src/main/resources/downloads/systems.txt
+++ b/peel-archetypes/peel-flink-bundle/src/main/resources/archetype-resources/__rootArtifactId__-bundle/src/main/resources/downloads/systems.txt
@@ -5,5 +5,6 @@ https://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz
 https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz
+http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz
 https://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz
 https://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz

--- a/peel-archetypes/peel-flinkspark-bundle/src/main/resources/archetype-resources/__rootArtifactId__-bundle/src/main/resources/downloads/systems.txt
+++ b/peel-archetypes/peel-flinkspark-bundle/src/main/resources/archetype-resources/__rootArtifactId__-bundle/src/main/resources/downloads/systems.txt
@@ -5,5 +5,6 @@ https://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz
 https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz
+http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz
 https://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz
 https://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz

--- a/peel-archetypes/peel-spark-bundle/src/main/resources/archetype-resources/__rootArtifactId__-bundle/src/main/resources/downloads/systems.txt
+++ b/peel-archetypes/peel-spark-bundle/src/main/resources/archetype-resources/__rootArtifactId__-bundle/src/main/resources/downloads/systems.txt
@@ -5,5 +5,6 @@ https://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz
 https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz
+http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz
 https://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz
 https://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz

--- a/peel-empty-bundle/src/main/resources/downloads/systems.txt
+++ b/peel-empty-bundle/src/main/resources/downloads/systems.txt
@@ -5,6 +5,7 @@ https://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz
 https://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz
 https://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz
+http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz
 http://stratosphere-bin.s3.amazonaws.com//flink-0.10-SNAPSHOT-bin-hadoop2.tgz
 https://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz
 https://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz

--- a/peel-extensions/src/main/resources/peel-extensions.xml
+++ b/peel-extensions/src/main/resources/peel-extensions.xml
@@ -81,6 +81,11 @@
         <constructor-arg name="configKey" value="flink" />
         <constructor-arg name="lifespan" value="EXPERIMENT"/>
     </bean>
+    <bean id="flink-0.10.1" class="org.peelframework.flink.beans.system.Flink" parent="system">
+        <constructor-arg name="version" value="0.10.1"/>
+        <constructor-arg name="configKey" value="flink" />
+        <constructor-arg name="lifespan" value="EXPERIMENT"/>
+    </bean>
 
     <!-- Spark -->
     <bean id="spark-1.3.1" class="org.peelframework.spark.beans.system.Spark" parent="system">

--- a/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
@@ -1,0 +1,19 @@
+# include common flink configuration
+include "reference.flink.conf"
+
+system {
+    flink {
+        path {
+            archive.url = "http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"
+            archive.md5 = "fbce243da19ff01fad0be46bdf780bbc"
+            archive.src = ${app.path.downloads}"/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"
+            home = ${system.flink.path.archive.dst}"/flink-0.10.1"
+        }
+        config {
+            # flink.yaml entries
+            yaml {
+                env.pid.dir = "/tmp/flink-0.10.1-pid"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The flink build with support for Hadoop 2.7 and Scala 2.10 is chosen.